### PR TITLE
Manage app connection state to the cache and reconnect automatically

### DIFF
--- a/powerberry-app/.flake8
+++ b/powerberry-app/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203, E501

--- a/powerberry-app/pyproject.toml
+++ b/powerberry-app/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/powerberry-app/src/main.py
+++ b/powerberry-app/src/main.py
@@ -1,9 +1,8 @@
-import sys
 import signal
+import sys
 
 from .app import App
 from .services.config import Config
-
 
 if __name__ == "__main__":
     # kill this app gracefully if we receive a SIGTERM from Docker

--- a/powerberry-app/src/services/cache.py
+++ b/powerberry-app/src/services/cache.py
@@ -13,13 +13,9 @@ class Cache:
     """
 
     def __init__(self, redis_host: str, redis_port: int):
-        self.redis = None
-
         self._redis_host = redis_host
         self._redis_port = redis_port
-        self._connect()
 
-    def _connect(self):
         self.redis = redis.Redis(
             host=self._redis_host,
             port=self._redis_port,
@@ -27,8 +23,14 @@ class Cache:
             decode_responses=True,
         )
 
-        self.redis.ping()
-        log.info(f"redis connected to {self._redis_host}:{self._redis_port}")
+    def connect(self) -> bool:
+        try:
+            self.redis.ping()
+            log.info(f"redis connected to {self._redis_host}:{self._redis_port}")
+            return True
+        except redis.RedisError as e:
+            log.warning(f"redis connection failed: {e}")
+        return False
 
     def get_devices(self) -> Set[str]:
         return self.redis.smembers("devices")

--- a/powerberry-app/src/services/config.py
+++ b/powerberry-app/src/services/config.py
@@ -1,7 +1,7 @@
-import os
-import sys
 import json
+import os
 import pathlib
+import sys
 
 from loguru import logger as log
 


### PR DESCRIPTION
This PR fixes #20.

The app will no wait until Redis is available. Further, if the connection is lost during processing, the app will try to re-connect automatically. Here is a brief example where I manually restarted the Redis container in-between.

![image](https://user-images.githubusercontent.com/10400532/158035311-1916d105-6376-4b16-895a-9898f57a100c.png)
